### PR TITLE
Two small fixes

### DIFF
--- a/SimpleBrowser/Query/Selectors/IdSelector.cs
+++ b/SimpleBrowser/Query/Selectors/IdSelector.cs
@@ -24,7 +24,7 @@ namespace SimpleBrowser.Query.Selectors
 			context.ResultSetInternal = results;
 		}
 
-		internal static readonly Regex RxSelector = new Regex(@"^\#(?<id>[A-Za-z_][A-Za-z0-9_]+)");
+        internal static readonly Regex RxSelector = new Regex(@"^\#(?<id>[A-Za-z_][A-Za-z0-9_\-:\.]+)");
 	}
 
 	public class IdSelectorCreator : XQuerySelectorCreator

--- a/SimpleBrowser/Query/XQueryResultsContext.cs
+++ b/SimpleBrowser/Query/XQueryResultsContext.cs
@@ -39,7 +39,7 @@ namespace SimpleBrowser.Query
 					{
 						var results = PreTranslateResultSet(_currentResultSet);
 						PreTranslateResultSet = null;
-						return results;
+						_currentResultSet = results;
 					}
 					return _currentResultSet;
 				}


### PR DESCRIPTION
- Updates the selector regex to allow for IDs like item-container. The - is a normal part of an id. See http://www.w3.org/TR/2000/REC-xml-20001006#id
  - The ResultSetInternal property has a bug in it causing the PreTranslteResultset method to be called only the first time the property is accessed.
