### PR TITLE
Fix bug with posting of checkbox when more than one item is selected.

### DIFF
--- a/SimpleBrowser/Internal/StringUtil.cs
+++ b/SimpleBrowser/Internal/StringUtil.cs
@@ -53,8 +53,11 @@ namespace SimpleBrowser
 			if (values == null)
 				return string.Empty;
 			List<string> list = new List<string>();
-			foreach (string key in values.Keys)
-				list.Add(HttpUtility.UrlEncode(key) + "=" + HttpUtility.UrlEncode(values[key]));
+            foreach (string key in values.Keys) 
+            {
+                foreach (string value in values.GetValues(key))
+                    list.Add(HttpUtility.UrlEncode(key) + "=" + HttpUtility.UrlEncode(value));
+            }
 			return list.Concat("&");
 		}
 


### PR DESCRIPTION
When using SimpleBrowser for SpecFlow headless browser testing, I ran into an error in which a checkbox with multiple values in the same name would post incorrectly. In my HTML I have multiple checkboxes with the same name, two of which are selected, e.g.

```
<input type="checkbox" class="checkbox required-checkbox" name="BusinessCategoriesSelection" value="1" checked="checked" /> Adult DayCare<br />
<input type="checkbox" class="checkbox required-checkbox" name="BusinessCategoriesSelection" value="2" checked="checked" /> Affordable Senior Housing<br />
```

It is posting like this:

```
BusinessCategoriesSelection=1%2c2
```

When it should be posting like this:

```
BusinessCategoriesSelection=1&BusinessCategoriesSelection=2
```

The problem is with the "MakeQueryString()" method in the "StringUtil" class was not considering multiple values with the same name properly and it was emitting a CSV list rather than the proper way of posting as multiple name=value in the post parameters. This change fixes that by adding a foreach loop for multiple values inside the key loop.
