### PR TITLE
No : in elements

### DIFF
--- a/SimpleBrowser/Query/Selectors/ElementSelector.cs
+++ b/SimpleBrowser/Query/Selectors/ElementSelector.cs
@@ -25,7 +25,7 @@ namespace SimpleBrowser.Query.Selectors
 				.Where(x => string.Compare(x.Name.LocalName, _name, true) == 0);
 		}
 
-		internal static readonly Regex RxSelector = new Regex(@"^[A-Za-z][A-Za-z0-9_\-:\.]*");
+		internal static readonly Regex RxSelector = new Regex(@"^[A-Za-z][A-Za-z0-9_\-]*");
 	}
 
 	public class ElementSelectorCreator : XQuerySelectorCreator


### PR DESCRIPTION
Although in XML, elements can have : and . in their name, in HTML and CSS these are used for namespacing and classes (as in span.icon). Therefore the ElementSelector should not select these characters.
