### PR TITLE
Fix for missing Host header

### DIFF
--- a/SimpleBrowser.UnitTests/OfflineTests/Http.cs
+++ b/SimpleBrowser.UnitTests/OfflineTests/Http.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace SimpleBrowser.UnitTests.OfflineTests
+{
+    [TestFixture]
+    class Http
+    {
+        [Test]
+        public void Host_Header_Should_Be_Sent()
+        {
+            Browser b = new Browser(Helper.GetAllways200RequestMocker());
+            HttpRequestLog lastLog = null;
+            b.RequestLogged += (br, l) =>
+            {
+                lastLog = l;
+            };
+            b.Navigate("http://www.blah.com/yadayada.html");
+            Assert.That(lastLog.RequestHeaders.AllKeys.Contains("Host"));
+            Assert.That(lastLog.RequestHeaders["Host"] == "www.blah.com");
+        }
+    }
+}

--- a/SimpleBrowser.UnitTests/SimpleBrowser.UnitTests.csproj
+++ b/SimpleBrowser.UnitTests/SimpleBrowser.UnitTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Issues.cs" />
     <Compile Include="OfflineTests\CommentElements.cs" />
     <Compile Include="OfflineTests\Forms.cs" />
+    <Compile Include="OfflineTests\Http.cs" />
     <Compile Include="OfflineTests\WeirdUrls.cs" />
     <Compile Include="OfflineTests\WindowsAndFrames.cs" />
     <Compile Include="OfflineTests\DecodedValue.cs" />

--- a/SimpleBrowser/Browser.cs
+++ b/SimpleBrowser/Browser.cs
@@ -568,6 +568,7 @@ namespace SimpleBrowser
 				}
 				foreach (var header in _extraHeaders)
 					req.Headers.Add(header);
+                
 				if (encodingType != null)
 					req.Headers.Add(HttpRequestHeader.ContentEncoding, encodingType);
 				if (_includeFormValues != null)
@@ -967,6 +968,7 @@ namespace SimpleBrowser
 			IHttpWebRequest req = _reqFactory.GetWebRequest(url);
 			req.Method = method;
 			req.ContentType = contentType; // "application/x-www-form-urlencoded";
+            req.Headers.Add("Host", url.Host);
 			req.UserAgent = UserAgent;
 			req.Accept = Accept ?? "*/*";
 			req.Timeout = timeoutMilliseconds;
@@ -980,6 +982,7 @@ namespace SimpleBrowser
 				req.Proxy = _proxy;
 			if (CurrentState != null)
 				req.Referer = this.Url.AbsoluteUri;
+            
 			return req;
 		}
 


### PR DESCRIPTION
See http://stackoverflow.com/questions/17843968/how-do-manually-set-the-host-header-when-using-simplebrowser-webdriver-with-sele

I think a browser should automatically add a host header to eacht request. All major browsers do this. 

PS. I've not contributed much lately and I see other people enthusiastically joined in, so I'll not push this, but rather do a pull request. :)
