### PR TITLE
Support setting the Host header.

### DIFF
--- a/SimpleBrowser.UnitTests/OfflineTests/HttpHeaderTests.cs
+++ b/SimpleBrowser.UnitTests/OfflineTests/HttpHeaderTests.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace SimpleBrowser.UnitTests.OfflineTests 
+{
+	[TestFixture]
+	public class HttpHeaderTests 
+	{
+		[Test]
+		public void AddHostHeaderDoesNotThrow() 
+		{
+			var browser = new Browser();
+			Assert.DoesNotThrow(() => browser.SetHeader("host:www.google.com"));
+		}
+	}
+}

--- a/SimpleBrowser.UnitTests/OnlineTests/HttpHeaderTests.cs
+++ b/SimpleBrowser.UnitTests/OnlineTests/HttpHeaderTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+
+namespace SimpleBrowser.UnitTests.OnlineTests 
+{
+	[TestFixture]
+	public class HttpHeaderTests 
+	{
+		[Test]
+		public void CustomHostHeaderIsSent()
+		{
+			var browser = new Browser();
+
+			browser.Navigate("http://204.144.122.42");
+			Assert.That(browser.RequestData().RequestHeaders["host"], Is.EqualTo("204.144.122.42"), "Expected host header to be default from url.");
+
+			// I happen to know that this domain name is not in dns (my company owns it)
+			// but that ip (also ours) is serving content for said domain.  
+			// Is there another way to confirm the overriden header is sent that does
+			// not depend on some random internet server?
+			browser.SetHeader("host:uscloud.asldkfhjawoeif.com");
+			browser.Navigate("http://204.144.122.42");
+
+			Assert.That(browser.RequestData().RequestHeaders["host"], Is.EqualTo("uscloud.asldkfhjawoeif.com"), "Expected the manually set host.");
+		}
+	}
+}

--- a/SimpleBrowser.UnitTests/SimpleBrowser.UnitTests.csproj
+++ b/SimpleBrowser.UnitTests/SimpleBrowser.UnitTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Issues.cs" />
     <Compile Include="OfflineTests\CommentElements.cs" />
     <Compile Include="OfflineTests\Forms.cs" />
+    <Compile Include="OfflineTests\HttpHeaderTests.cs" />
     <Compile Include="OfflineTests\WeirdUrls.cs" />
     <Compile Include="OfflineTests\WindowsAndFrames.cs" />
     <Compile Include="OfflineTests\DecodedValue.cs" />
@@ -60,6 +61,7 @@
     <Compile Include="OfflineTests\QueryTests.cs" />
     <Compile Include="OfflineTests\Selectors.cs" />
     <Compile Include="OfflineTests\Uploading.cs" />
+    <Compile Include="OnlineTests\HttpHeaderTests.cs" />
     <Compile Include="OnlineTests\VerifyGZipEncoding.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/SimpleBrowser/Browser.cs
+++ b/SimpleBrowser/Browser.cs
@@ -567,8 +567,13 @@ namespace SimpleBrowser
 					return false;
 				}
 				foreach (var header in _extraHeaders)
-					req.Headers.Add(header);
-				if (encodingType != null)
+				{
+					if (header.StartsWith("host:", StringComparison.OrdinalIgnoreCase))
+						req.Host = header.Split(':')[1];
+					else
+						req.Headers.Add(header);
+				}
+			  if (encodingType != null)
 					req.Headers.Add(HttpRequestHeader.ContentEncoding, encodingType);
 				if (_includeFormValues != null)
 				{
@@ -609,7 +614,7 @@ namespace SimpleBrowser
 					stream.Write(data, 0, data.Length);
 					stream.Close();
 				}
-
+				
 				if (contentType != null)
 					req.ContentType = contentType;
 

--- a/SimpleBrowser/Network/IHttpWebRequest.cs
+++ b/SimpleBrowser/Network/IHttpWebRequest.cs
@@ -36,5 +36,7 @@ namespace SimpleBrowser.Network
 		IWebProxy Proxy { get; set; }
 
 		string Referer { get; set; }
+
+		string Host { get; set; }
 	}
 }

--- a/SimpleBrowser/Network/WebRequestWrapper.cs
+++ b/SimpleBrowser/Network/WebRequestWrapper.cs
@@ -170,6 +170,17 @@ namespace SimpleBrowser.Network
 			}
 		}
 
-		#endregion
+		public string Host
+		{
+			get
+			{
+				return _wr.Host;
+			}
+			set
+			{
+				_wr.Host = value;
+			}
+		}
+	  #endregion
 	}
 }


### PR DESCRIPTION
While a Browser.SetHeader() method exists, it throws an exception when setting 'host'.  This change adds support for setting 'host' properly on the underlying implementation.
