### PR TITLE
Upgrade Referrer Policy States to match specifications. …

### DIFF
--- a/SimpleBrowser.UnitTests/OnlineTests/RefererHeader.cs
+++ b/SimpleBrowser.UnitTests/OnlineTests/RefererHeader.cs
@@ -1,163 +1,188 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using NUnit.Framework;
+﻿// -----------------------------------------------------------------------
+// <copyright file="RefererHeader.cs" company="SimpleBrowser">
+// See https://github.com/SimpleBrowserDotNet/SimpleBrowser/blob/master/readme.md
+// </copyright>
+// -----------------------------------------------------------------------
 
 namespace SimpleBrowser.UnitTests.OnlineTests
 {
-	[TestFixture]
-	public class RefererHeader
-	{
-		[Test]
-		public void When_Testing_Referer_DefaultMode_Typical()
-		{
-			string startingUrl = "http://afn.org/~afn07998/simplebrowser/test1.htm";
+    using NUnit.Framework;
 
-			Browser b = new Browser();
-			Assert.AreEqual(b.RefererMode, Browser.RefererModes.Default);
+    /// <summary>
+    /// A test class for testing the $referer$ header.
+    /// </summary>
+    [TestFixture]
+    public class RefererHeader
+    {
+        /// <summary>
+        /// Tests the None When Downgrade Referrer Policy State when not transitioning from secure to unsecure
+        /// </summary>
+        [Test]
+        public void When_Testing_Referer_NoneWhenDowngrade_Typical()
+        {
+            string startingUrl = "http://afn.org/~afn07998/simplebrowser/test1.htm";
 
-			b.Navigate(startingUrl);
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
+            Browser b = new Browser();
+            Assert.AreEqual(b.RefererMode, Browser.RefererModes.NoneWhenDowngrade);
 
-			var link = b.Find("test1");
-			Assert.IsNotNull(link);
+            b.Navigate(startingUrl);
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
 
-			link.Click();
-			Assert.IsNotNull(b.CurrentState);
-			Assert.AreEqual(b.Referer.ToString(), startingUrl);
-		}
+            var link = b.Find("test1");
+            Assert.IsNotNull(link);
 
-		[Test]
-		public void When_Testing_Referer_NeverMode_Typical()
-		{
-			string startingUrl = "http://afn.org/~afn07998/simplebrowser/test1.htm";
+            link.Click();
+            Assert.IsNotNull(b.CurrentState);
+            Assert.AreEqual(b.Referer.ToString(), startingUrl);
+        }
 
-			Browser b = new Browser();
-			b.RefererMode = Browser.RefererModes.Never;
-			Assert.AreEqual(b.RefererMode, Browser.RefererModes.Never);
+        /// <summary>
+        /// Tests the None Referrer Policy State
+        /// </summary>
+        [Test]
+        public void When_Testing_Referer_None_Typical()
+        {
+            string startingUrl = "http://afn.org/~afn07998/simplebrowser/test1.htm";
 
+            Browser b = new Browser();
+            b.RefererMode = Browser.RefererModes.None;
+            Assert.AreEqual(b.RefererMode, Browser.RefererModes.None);
 
-			b.Navigate(startingUrl);
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
+            b.Navigate(startingUrl);
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
 
-			var link = b.Find("test1");
-			Assert.IsNotNull(link);
+            var link = b.Find("test1");
+            Assert.IsNotNull(link);
 
-			link.Click();
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
-		}
+            link.Click();
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
+        }
 
-		[Test]
-		public void When_Testing_Referer_DefaultMode_Secure_Transition()
-		{
-			string startingUrl = "https://www.example.com/";
+        /// <summary>
+        /// Tests the None When Downgrade Referrer Policy State when transitioning from secure to unsecure.
+        /// </summary>
+        [Test]
+        public void When_Testing_Referer_NoneWhenDowngrade_Secure_Transition()
+        {
+            string startingUrl = "https://www.example.com/";
 
-			Browser b = new Browser();
-			Assert.AreEqual(b.RefererMode, Browser.RefererModes.Default);
+            Browser b = new Browser();
+            Assert.AreEqual(b.RefererMode, Browser.RefererModes.NoneWhenDowngrade);
 
-			b.Navigate(startingUrl);
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
+            b.Navigate(startingUrl);
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
 
-			var link = b.Find(ElementType.Anchor, FindBy.Text, "More information...");
-			Assert.IsNotNull(link);
+            var link = b.Find(ElementType.Anchor, FindBy.Text, "More information...");
+            Assert.IsNotNull(link);
 
-			link.Click();
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
-		}
+            link.Click();
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
+        }
 
-		[Test]
-		public void When_Testing_Referer_OriginMode_Typical()
-		{
-			string startingUrl = "http://www.iana.org/domains/reserved";
+        /// <summary>
+        /// Tests the Origin Referrer Policy State
+        /// </summary>
+        [Test]
+        public void When_Testing_Referer_Origin_Typical()
+        {
+            string startingUrl = "http://www.iana.org/domains/reserved";
 
-			Browser b = new Browser();
-			b.RefererMode = Browser.RefererModes.Origin;
-			Assert.AreEqual(b.RefererMode, Browser.RefererModes.Origin);
+            Browser b = new Browser();
+            b.RefererMode = Browser.RefererModes.Origin;
+            Assert.AreEqual(b.RefererMode, Browser.RefererModes.Origin);
 
-			b.Navigate(startingUrl);
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
+            b.Navigate(startingUrl);
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
 
-			var link = b.Find(ElementType.Anchor, "href", "/");
-			Assert.IsNotNull(link);
+            var link = b.Find(ElementType.Anchor, "href", "/");
+            Assert.IsNotNull(link);
 
-			link.Click();
-			Assert.IsNotNull(b.CurrentState);
-			Assert.AreEqual(b.Referer.ToString(), "http://www.iana.org/");
-		}
+            link.Click();
+            Assert.IsNotNull(b.CurrentState);
+            Assert.AreEqual(b.Referer.ToString(), "http://www.iana.org/");
+        }
 
-		[Test]
-		public void When_Testing_Referer_AlwaysMode_Secure_Transition()
-		{
-			string startingUrl = "https://www.example.com/";
+        /// <summary>
+        /// Tests the Unsafe URL Referrer Policy State with a secure transition.
+        /// </summary>
+        [Test]
+        public void When_Testing_Referer_Unsafe_Url_Secure_Transition()
+        {
+            string startingUrl = "https://www.example.com/";
 
-			Browser b = new Browser();
-			b.RefererMode = Browser.RefererModes.Always;
-			Assert.AreEqual(b.RefererMode, Browser.RefererModes.Always);
+            Browser b = new Browser();
+            b.RefererMode = Browser.RefererModes.UnsafeUrl;
+            Assert.AreEqual(b.RefererMode, Browser.RefererModes.UnsafeUrl);
 
-			b.Navigate(startingUrl);
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
+            b.Navigate(startingUrl);
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
 
-			var link = b.Find(ElementType.Anchor, FindBy.Text, "More information...");
-			Assert.IsNotNull(link);
+            var link = b.Find(ElementType.Anchor, FindBy.Text, "More information...");
+            Assert.IsNotNull(link);
 
-			string targetHref = link.GetAttribute("href");
-			Assert.AreEqual(targetHref, "http://www.iana.org/domains/example");
+            string targetHref = link.GetAttribute("href");
+            Assert.AreEqual(targetHref, "http://www.iana.org/domains/example");
 
-			link.Click();
-			Assert.IsNotNull(b.CurrentState);
-			Assert.AreEqual(b.Referer.ToString(), startingUrl);
+            link.Click();
+            Assert.IsNotNull(b.CurrentState);
+            Assert.AreEqual(b.Referer.ToString(), startingUrl);
 
-			// This explicitly tests that a 300 redirect preserves the original referrer.
-			Assert.AreEqual(b.CurrentState.Url.ToString(), "http://www.iana.org/domains/reserved");
-			Assert.AreNotEqual(b.Referer.ToString(), targetHref);
-		}
+            // This explicitly tests that a 300 redirect preserves the original referrer.
+            Assert.AreEqual(b.CurrentState.Url.ToString(), "http://www.iana.org/domains/reserved");
+            Assert.AreNotEqual(b.Referer.ToString(), targetHref);
+        }
 
-		[Test]
-		public void When_Testing_Referer_MetaReferrer()
-		{
-			string startingUrl = "http://afn.org/~afn07998/simplebrowser/testmeta.htm";
+        /// <summary>
+        /// Test the Referrer Policy State when using the referrer meta tag.
+        /// </summary>
+        [Test]
+        public void When_Testing_Referer_MetaReferrer()
+        {
+            string startingUrl = "http://afn.org/~afn07998/simplebrowser/testmeta.htm";
 
-			Browser b = new Browser();
-			Assert.AreEqual(b.RefererMode, Browser.RefererModes.Default);
+            Browser b = new Browser();
+            Assert.AreEqual(b.RefererMode, Browser.RefererModes.NoneWhenDowngrade);
 
-			b.Navigate(startingUrl);
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
+            b.Navigate(startingUrl);
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
 
-			var link = b.Find("test1");
-			Assert.IsNotNull(link);
+            var link = b.Find("test1");
+            Assert.IsNotNull(link);
 
-			link.Click();
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
-		}
+            link.Click();
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
+        }
 
-		[Test]
-		public void When_Testing_Referer_RelNoReferrer()
-		{
-			string startingUrl = "http://afn.org/~afn07998/simplebrowser/testrel.htm";
+        /// <summary>
+        /// Test the Referrer Policy State when using the anchor $rel$ attribute.
+        /// </summary>
+        [Test]
+        public void When_Testing_Referer_RelNoReferrer()
+        {
+            string startingUrl = "http://afn.org/~afn07998/simplebrowser/testrel.htm";
 
-			Browser b = new Browser();
-			Assert.AreEqual(b.RefererMode, Browser.RefererModes.Default);
+            Browser b = new Browser();
+            Assert.AreEqual(b.RefererMode, Browser.RefererModes.NoneWhenDowngrade);
 
-			b.Navigate(startingUrl);
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
+            b.Navigate(startingUrl);
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
 
-			var link = b.Find("test1");
-			Assert.IsNotNull(link);
+            var link = b.Find("test1");
+            Assert.IsNotNull(link);
 
-			link.Click();
-			Assert.IsNotNull(b.CurrentState);
-			Assert.IsNull(b.Referer);
-		}
-	}
+            link.Click();
+            Assert.IsNotNull(b.CurrentState);
+            Assert.IsNull(b.Referer);
+        }
+    }
 }


### PR DESCRIPTION
… Previously, when no specification existed, "recommended" values were used. The current code supports both the legacy and modern values.